### PR TITLE
add beforeNow & afterNow rules

### DIFF
--- a/lib/extendedRules.coffee
+++ b/lib/extendedRules.coffee
@@ -58,7 +58,7 @@ class ExtendedRules
         else      reject message
 
     ###*
-     * Make sure field under validation is afterNow + or - offset
+     * Make sure field under validation is afterOffsetOf + or - offset
      * @param  {[object]}   data    [global data object]
      * @param  {[string]}   field   [field to be validated]
      * @param  {[string]}   message [message to be printed]
@@ -77,7 +77,7 @@ class ExtendedRules
      *                                milliseconds  ms
      * @return {[promise]}  returns final promise
     ###
-    afterNow : (data,field,message,args) ->
+    afterOffsetOf : (data,field,message,args) ->
 
       new PROMISE (resolve,reject) ->
         [offset = 0,key = 'days'] = args.toString().split ","
@@ -93,7 +93,7 @@ class ExtendedRules
 
 
     ###*
-     * Make sure field under validation is beforeNow + or - offset
+     * Make sure field under validation is beforeOffsetOf + or - offset
      * @param  {[object]}   data    [global data object]
      * @param  {[string]}   field   [field to be validated]
      * @param  {[string]}   message [message to be printed]
@@ -112,7 +112,7 @@ class ExtendedRules
      *                                milliseconds  ms
      * @return {[promise]}  returns final promise
     ###
-    beforeNow : (data,field,message,args) ->
+    beforeOffsetOf : (data,field,message,args) ->
 
       new PROMISE (resolve,reject) ->
         [offset=0,key='days'] = args.toString().split ","

--- a/lib/extendedRules.coffee
+++ b/lib/extendedRules.coffee
@@ -57,6 +57,74 @@ class ExtendedRules
         then      resolve "is after date"
         else      reject message
 
+    ###*
+     * Make sure field under validation is afterNow + or - offset
+     * @param  {[object]}   data    [global data object]
+     * @param  {[string]}   field   [field to be validated]
+     * @param  {[string]}   message [message to be printed]
+     * @param  {[string]}   args    [arguments passed along with validator]
+     *                      args.0  [offset, positive or negative]
+     *                      args.1  [type of offset accepted by moment().add]
+     *                                Key           Shorthand
+     *                                years         y
+     *                                quarters      Q
+     *                                months        M
+     *                                weeks         w
+     *                                days          d
+     *                                hours         h
+     *                                minutes       m
+     *                                seconds       s
+     *                                milliseconds  ms
+     * @return {[promise]}  returns final promise
+    ###
+    afterNow : (data,field,message,args) ->
+
+      new PROMISE (resolve,reject) ->
+        [offset = 0,key = 'days'] = args.toString().split ","
+
+        if        (not _.has data,field) then return resolve "empty field"
+
+        fieldValue = MOMENT data[field]
+        pivot      = MOMENT().add offset, key
+
+        if        fieldValue.isAfter pivot
+        then      resolve "is after date"
+        else      reject message
+
+
+    ###*
+     * Make sure field under validation is beforeNow + or - offset
+     * @param  {[object]}   data    [global data object]
+     * @param  {[string]}   field   [field to be validated]
+     * @param  {[string]}   message [message to be printed]
+     * @param  {[string]}   args    [arguments passed along with validator]
+     *                      args.0  [offset, positive or negative]
+     *                      args.1  [type of offset accepted by moment().add]
+     *                                Key           Shorthand
+     *                                years         y
+     *                                quarters      Q
+     *                                months        M
+     *                                weeks         w
+     *                                days          d
+     *                                hours         h
+     *                                minutes       m
+     *                                seconds       s
+     *                                milliseconds  ms
+     * @return {[promise]}  returns final promise
+    ###
+    beforeNow : (data,field,message,args) ->
+
+      new PROMISE (resolve,reject) ->
+        [offset=0,key='days'] = args.toString().split ","
+
+        if        (not _.has data,field) then return resolve "empty field"
+        fieldValue = MOMENT data[field]
+        pivot      = MOMENT().add offset, key
+
+        if        fieldValue.isBefore pivot
+        then      resolve "is before date"
+        else      reject message
+
 
     ###*
      * Executes defined regex on value for a given

--- a/test/rules.test.coffee
+++ b/test/rules.test.coffee
@@ -618,6 +618,75 @@ describe "#Rules", () ->
           should.not.exist err
 
 
+
+    context "afterNow", () ->
+
+      field = 'expiry_date'
+      message = 'Expiry date cannot be past'
+      ruleDefination = '1,days'
+
+      it "should return error when value passed is not after defined offset" , () ->
+
+        data =
+          expiry_date: moment().format "YYYY-MM-DD"
+
+        rules.validations.afterNow data,field,message,ruleDefination
+        .then (success) ->
+          should.not.exist success
+        .catch (err) ->
+          should.exist err
+          expect(err).to.equal message
+
+      it "should return error when value passed is same as defined offset" , () ->
+
+        data =
+          expiry_date: moment().add(1,'days').toISOString()
+
+        rules.validations.afterNow data,field,message,ruleDefination
+        .then (success) ->
+          should.not.exist success
+        .catch (err) ->
+          should.exist err
+          expect(err).to.equal message
+
+
+
+      it "should work fine when date passed is after the defined offset" , () ->
+
+        data =
+          expiry_date: moment().add(1,'days').add(1,'seconds').toISOString()
+
+        rules.validations.afterNow data,field,message,ruleDefination
+        .then (success) ->
+          should.exist success
+        .catch (err) ->
+          should.not.exist err
+
+
+      it "should validate against now with no args as offset" , () ->
+        data =
+          expiry_date: moment().toISOString()
+
+        rules.validations.afterNow data,field,message,''
+        .then (success) ->
+          should.not.exist success
+        .catch (err) ->
+          should.exist err
+          expect(err).to.equal message
+
+
+      it "should work fine when date passed is after now with no args as offset" , () ->
+
+        data =
+          expiry_date: moment().add(1,'seconds').toISOString()
+
+        rules.validations.afterNow data,field,message,''
+        .then (success) ->
+          should.exist success
+        .catch (err) ->
+          should.not.exist err
+
+
     context "before", () ->
 
       field = 'dob'
@@ -656,6 +725,76 @@ describe "#Rules", () ->
           dob: moment().subtract(1,'day').format "YYYY-MM-DD"
 
         rules.validations.before data,field,message,ruleDefination
+        .then (success) ->
+          should.exist success
+        .catch (err) ->
+          should.not.exist err
+
+
+
+    context "beforeNow", () ->
+
+      field = 'dob'
+      message = 'Your dob cannot be after today'
+      ruleDefination = '1,days'
+
+      it "should return error when value passed is after defined offset" , () ->
+
+        data =
+          dob: moment().add(1,'day').add(1, 'seconds').toISOString()
+
+        rules.validations.beforeNow data,field,message,ruleDefination
+        .then (success) ->
+          should.not.exist success
+        .catch (err) ->
+          should.exist err
+          expect(err).to.equal message
+
+
+      it "should return error when value passed is same as defined offset" , () ->
+        # mimic now date as pivot will be created later
+        data =
+          dob: moment().add(1, 's').toISOString()
+
+        rules.validations.beforeNow data,field,message,'0'
+        .then (success) ->
+          should.not.exist success
+        .catch (err) ->
+          should.exist err
+          expect(err).to.equal message
+
+
+
+      it "should work fine when date passed is before defined offset" , () ->
+
+        data =
+          dob: moment().toISOString()
+
+        rules.validations.beforeNow data,field,message,ruleDefination
+        .then (success) ->
+          should.exist success
+        .catch (err) ->
+          should.not.exist err
+
+
+      it "should validate against now with no args as offset" , () ->
+        # mimic future date
+        data =
+          dob: moment().add(1, 's').toISOString()
+
+        rules.validations.beforeNow data,field,message,''
+        .then (success) ->
+          should.not.exist success
+        .catch (err) ->
+          should.exist err
+          expect(err).to.equal message
+
+
+      it "should work fine when date passed is before now with no args as offset" , () ->
+        data =
+          dob: moment().subtract(1, 's').toISOString()
+
+        rules.validations.beforeNow data,field,message,''
         .then (success) ->
           should.exist success
         .catch (err) ->
@@ -2225,7 +2364,7 @@ describe "#Rules", () ->
 
       it "should work when data passed is not a string and is required", () ->
 
-        data = 
+        data =
           username: [0,1]
 
         rules.validations.required data,field,message

--- a/test/rules.test.coffee
+++ b/test/rules.test.coffee
@@ -619,7 +619,7 @@ describe "#Rules", () ->
 
 
 
-    context "afterNow", () ->
+    context "afterOffsetOf", () ->
 
       field = 'expiry_date'
       message = 'Expiry date cannot be past'
@@ -630,7 +630,7 @@ describe "#Rules", () ->
         data =
           expiry_date: moment().format "YYYY-MM-DD"
 
-        rules.validations.afterNow data,field,message,ruleDefination
+        rules.validations.afterOffsetOf data,field,message,ruleDefination
         .then (success) ->
           should.not.exist success
         .catch (err) ->
@@ -642,7 +642,7 @@ describe "#Rules", () ->
         data =
           expiry_date: moment().add(1,'days').toISOString()
 
-        rules.validations.afterNow data,field,message,ruleDefination
+        rules.validations.afterOffsetOf data,field,message,ruleDefination
         .then (success) ->
           should.not.exist success
         .catch (err) ->
@@ -656,7 +656,7 @@ describe "#Rules", () ->
         data =
           expiry_date: moment().add(1,'days').add(1,'seconds').toISOString()
 
-        rules.validations.afterNow data,field,message,ruleDefination
+        rules.validations.afterOffsetOf data,field,message,ruleDefination
         .then (success) ->
           should.exist success
         .catch (err) ->
@@ -667,7 +667,7 @@ describe "#Rules", () ->
         data =
           expiry_date: moment().toISOString()
 
-        rules.validations.afterNow data,field,message,''
+        rules.validations.afterOffsetOf data,field,message,''
         .then (success) ->
           should.not.exist success
         .catch (err) ->
@@ -680,7 +680,7 @@ describe "#Rules", () ->
         data =
           expiry_date: moment().add(1,'seconds').toISOString()
 
-        rules.validations.afterNow data,field,message,''
+        rules.validations.afterOffsetOf data,field,message,''
         .then (success) ->
           should.exist success
         .catch (err) ->
@@ -732,7 +732,7 @@ describe "#Rules", () ->
 
 
 
-    context "beforeNow", () ->
+    context "beforeOffsetOf", () ->
 
       field = 'dob'
       message = 'Your dob cannot be after today'
@@ -743,7 +743,7 @@ describe "#Rules", () ->
         data =
           dob: moment().add(1,'day').add(1, 'seconds').toISOString()
 
-        rules.validations.beforeNow data,field,message,ruleDefination
+        rules.validations.beforeOffsetOf data,field,message,ruleDefination
         .then (success) ->
           should.not.exist success
         .catch (err) ->
@@ -756,7 +756,7 @@ describe "#Rules", () ->
         data =
           dob: moment().add(1, 's').toISOString()
 
-        rules.validations.beforeNow data,field,message,'0'
+        rules.validations.beforeOffsetOf data,field,message,'0'
         .then (success) ->
           should.not.exist success
         .catch (err) ->
@@ -770,7 +770,7 @@ describe "#Rules", () ->
         data =
           dob: moment().toISOString()
 
-        rules.validations.beforeNow data,field,message,ruleDefination
+        rules.validations.beforeOffsetOf data,field,message,ruleDefination
         .then (success) ->
           should.exist success
         .catch (err) ->
@@ -782,7 +782,7 @@ describe "#Rules", () ->
         data =
           dob: moment().add(1, 's').toISOString()
 
-        rules.validations.beforeNow data,field,message,''
+        rules.validations.beforeOffsetOf data,field,message,''
         .then (success) ->
           should.not.exist success
         .catch (err) ->
@@ -794,7 +794,7 @@ describe "#Rules", () ->
         data =
           dob: moment().subtract(1, 's').toISOString()
 
-        rules.validations.beforeNow data,field,message,''
+        rules.validations.beforeOffsetOf data,field,message,''
         .then (success) ->
           should.exist success
         .catch (err) ->


### PR DESCRIPTION
add date relative rules: `afterNow` `beforeNow`

Often (at least in my case), date rules are relative to now.

``` js

var indic = new(require('indicative'));
var moment = require('moment');

var rules = {
    exp_date: 'afterNow:12,months'
};

var data = {
   exp_date: moment().add(14, 'months').toISOString()
};

indic.validate(rules, data)
.then(function() { // valid data });
```

function arguments are 
- `offset` : positive or negative number
- `key`: key values of `moment().add` [add](http://momentjs.com/docs/#/manipulating/add)

If it suits you, could you please accept this PR.

Thanks
