### PR TITLE
Allow emails with address extension, e.g. foo+baz@bar.com

### DIFF
--- a/src/Raw/index.js
+++ b/src/Raw/index.js
@@ -12,7 +12,7 @@ const moment = require('moment')
  * list of creepy regex, no they work nice
  */
 const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i
-const emailRegex = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i
+const emailRegex = /^([\w-]+(?:\.[\w-]+)*)(\+[\w\.-]+)?@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i
 const phoneRegex = /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/
 const creditCardRegex = /^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|6(?:011|5[0-9]{2})[0-9]{12}|(?:2131|1800|35\d{3})\d{11})$/
 const alphaNumericRegex = /^[a-z0-9]+$/i

--- a/test/validations.spec.js
+++ b/test/validations.spec.js
@@ -167,6 +167,16 @@ describe('Validations', function() {
       expect(passes).to.equal('validation passed')
     })
 
+    it('should work fine when valid email with extension is provided', function * () {
+      const data = {email:'foo+baz@bar.com'}
+      const field = 'email'
+      const message = 'email must be email'
+      const get = dotProp.get
+      const args = []
+      const passes = yield Validations.email(data, field, message, args, get)
+      expect(passes).to.equal('validation passed')
+    })
+
   })
 
   context('Accepted', function () {


### PR DESCRIPTION
This replaces #43.
