### PR TITLE
docs(API): use correct parameters for validate and validateAll

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -32,7 +32,7 @@ const data = {
 }
 
 indicative
-.validate(schema, data)
+.validate(data, schema)
 .then(function () {
   // validation passed  
 })
@@ -45,7 +45,7 @@ indicative
 Validate all will validate all fields even after errors are thrown and return an array of error messages.
 
 ```javascript,line-numbers
-indicative.validateAll(schema, data)
+indicative.validateAll(data, schema)
 ```
 
 ## Rules
@@ -112,7 +112,7 @@ const data = {
 }
 
 indicative
-.validate(schema, data)
+.validate(data, schema)
 .then(function () {
   // validation passed  
 })
@@ -154,7 +154,7 @@ const messages = {
 }
 
 indicative
-.validate(rules, schema, messages)
+.validate(data, schema, messages)
 .then(function () {
   // validation passed  
 })
@@ -176,7 +176,7 @@ const messages = {
 
 
 indicative
-.validate(rules, schema, messages)
+.validate(data, schema, messages)
 .then(function () {
   // validation passed  
 })

--- a/docs/schema-rules.md
+++ b/docs/schema-rules.md
@@ -11,7 +11,7 @@ const schema = {
 }
 
 indicative
-.validate(schema, data)
+.validate(data, schema)
 .then (function () {
   // validation passed
 })


### PR DESCRIPTION
In the docs the parameter order is `schema, data` but must be `data, schema`.
