### PR TITLE
chore(rules): add confirmed rules

### DIFF
--- a/src/Validations/index.js
+++ b/src/Validations/index.js
@@ -31,6 +31,33 @@ const skippable = function (value) {
 }
 
 /**
+ * @description enforces a field to be confirmed by another.
+ * @method email
+ * @param  {Object} data
+ * @param  {String} field
+ * @param  {String} message
+ * @param  {Array} args
+ * @param  {Function} get
+ * @return {Object}
+ * @public
+ */
+Validations.confirmed = function (data, field, message, args, get) {
+  return new Promise(function (resolve, reject) {
+    const fieldValue = get(data, field)
+    const confirmedFieldValue = get(data, `${field}_confirmation`)
+    if (skippable(fieldValue)) {
+      resolve('validation skipped')
+      return
+    }
+    if (Raw.same(fieldValue, confirmedFieldValue)) {
+      resolve('validation passed')
+      return
+    }
+    reject(message)
+  })
+}
+
+/**
  * @description enforces a field to be an email if present
  * @method email
  * @param  {Object} data

--- a/test/raw.spec.js
+++ b/test/raw.spec.js
@@ -1067,7 +1067,5 @@ describe('Raw Validator', function() {
       const isBeforeOffset = Is.beforeOffsetOf(moment().subtract(13,'months'), 12, 'months')
       expect(isBeforeOffset).to.equal(true)
     })
-
   })
-
 });

--- a/test/validations.spec.js
+++ b/test/validations.spec.js
@@ -3031,5 +3031,80 @@ describe('Validations', function() {
       expect(passes).to.equal('validation skipped')
     })
   })
+
+  context('Confirmation', function () {
+    ///////////////////
+    // test suite 200 //
+    ///////////////////
+    it('should work fine when the confirmed field is equal', function * () {
+      const data = { password: '1234', password_confirmation: '1234' }
+      const field = 'password'
+      const message = 'Password does not match!'
+      const get = _.get
+      const args = []
+      const passes = yield Validations.confirmed(data, field, message, args, get)
+      expect(passes).to.equal('validation passed')
+    })
+
+    ///////////////////
+    // test suite 201 //
+    ///////////////////
+    it('should throw an error when then confirmed field isn\'t equal', function * () {
+      const data = { password: '1234', password_confirmation: '12345' }
+      const field = 'password'
+      const message = 'Password does not match!'
+      const get = _.get
+      const args = []
+      try {
+        const passes = yield Validations.confirmed(data, field, message, args, get)
+        expect(passes).not.to.exist()
+      } catch(e) {
+        expect(e).to.equal(message)
+      }
+    })
+
+    ///////////////////
+    // test suite 202 //
+    ///////////////////
+    it('should throw an error when then confirmed field isn\'t equal', function * () {
+      const data = { password: '1234', password_confirmation: undefined }
+      const field = 'password'
+      const message = 'Password does not match!'
+      const get = _.get
+      const args = []
+      try {
+        const passes = yield Validations.confirmed(data, field, message, args, get)
+        expect(passes).not.to.exist()
+      } catch(e) {
+        expect(e).to.equal(message)
+      }
+    })
+
+    ///////////////////
+    // test suite 203 //
+    ///////////////////
+    it('should skip validation when field value is not defined', function * () {
+      const data = { }
+      const field = 'password'
+      const message = 'Password does not match!'
+      const get = _.get
+      const args = []
+      const passes = yield Validations.confirmed(data, field, message, args, get)
+      expect(passes).to.equal('validation skipped')
+    })
+
+    ///////////////////
+    // test suite 204 //
+    ///////////////////
+    it('should skip validation when field value is undefined', function * () {
+      const data = { password: undefined, password_confirmation: undefined }
+      const field = 'password'
+      const message = 'Password does not match!'
+      const get = _.get
+      const args = []
+      const passes = yield Validations.confirmed(data, field, message, args, get)
+      expect(passes).to.equal('validation skipped')
+    })
+  })
 })
 


### PR DESCRIPTION
This new rule allow us to validate a field with a confirmation field.

The confirmation field should have the same name suffixed with `_confirmation`.

**Example:**

``` html
<!-- Register Form -->
<form action="{{ 'users.store' | route }}" method="POST">

  <!-- ... -->

  <!-- Password Field -->
  <div class="form-input">
    <input name="password" type="password" placeholder="Mot de passe">
  </div>

  <!-- Password Confirmation Field -->
  <div class="form-input">
    <input name="password_confirmation" type="password" placeholder="Confirmez votre mot de passe">
  </div>

  <!-- ... -->

</form>
```

``` js
// Controller

* store(request, response) {
  const rules = {
    'password': 'required|confirmed'
  }

  const validation = yield Validator.validate(rules, request.all())

  // ...

}
```
