### PR TITLE
Allow long TLDs in email and url validation

### DIFF
--- a/src/Raw/index.js
+++ b/src/Raw/index.js
@@ -14,8 +14,8 @@ const moment = require('moment')
 /**
  * list of creepy regex, no they work nice
  */
-const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i
-const emailRegex = /^([\w-]+(?:\.[\w-]+)*)(\+[\w\.-]+)?@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i
+const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i
+const emailRegex = /^([\w-]+(?:\.[\w-]+)*)(\+[\w\.-]+)?@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,63}(?:\.[a-z]{2})?)$/i
 const phoneRegex = /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/
 const creditCardRegex = /^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|6(?:011|5[0-9]{2})[0-9]{12}|(?:2131|1800|35\d{3})\d{11})$/
 const alphaNumericRegex = /^[a-z0-9]+$/i

--- a/test/raw.spec.js
+++ b/test/raw.spec.js
@@ -451,6 +451,22 @@ describe('Raw Validator', function() {
       expect(isUrl).to.equal(true)
     })
 
+    //////////////////////////
+    // test suite add later //
+    //////////////////////////
+    it('should return true when input contains 63 characters TLD', function () {
+      const isUrl = Is.url('https://example.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk')
+      expect(isUrl).to.equal(true)
+    })
+
+    //////////////////////////
+    // test suite add later //
+    //////////////////////////
+    it('should return false when input contains more than 63 characters TLD', function () {
+      const isUrl = Is.url('https://example.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl')
+      expect(isUrl).to.equal(false)
+    })
+
     ///////////////////
     // test suite 55 //
     ///////////////////
@@ -486,9 +502,17 @@ describe('Raw Validator', function() {
     ///////////////////
     // test suite 59 //
     ///////////////////
-    it('should return true when input is a valid email address with different TLD', function () {
-      const isEmail = Is.email('someone@example.org')
+    it('should return true when input is a valid email address with 63 characters TLD', function () {
+      const isEmail = Is.email('someone@example.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk')
       expect(isEmail).to.equal(true)
+    })
+
+    //////////////////////////
+    // test suite add later //
+    //////////////////////////
+    it('should return false when input is not a valid email address with more than 63 characters TLD', function () {
+      const isEmail = Is.email('someone@example.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl')
+      expect(isEmail).to.equal(false)
     })
 
     //////////////////////////


### PR DESCRIPTION
- Allow long TLDs such as .ventures
- 63 character max [RFC1034](https://tools.ietf.org/html/rfc1034)
- Remove duplicate test 58 and 59
- Add tests

Link https://en.wikipedia.org/wiki/Domain_Name_System#cite_ref-rfc1034_1-2
