### PR TITLE
bug fixed with no-useless-escape

### DIFF
--- a/src/Parser/index.js
+++ b/src/Parser/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-useless-escape */
+
 'use strict'
 
 /**

--- a/src/Raw/index.js
+++ b/src/Raw/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-useless-escape */
+
 'use strict'
 
 /**


### PR DESCRIPTION
"If you don’t want to be notified about unnecessary escapes, you can safely disable this rule." [Eslint](http://eslint.org/docs/rules/no-useless-escape).

I added this line to two files "/* eslint-disable no-useless-escape */" to correct the problem with the test and permit run it.

I opened an [Issue](https://github.com/poppinss/indicative/issues/127) 

Please feel free to contact me if you have any question.