### PR TITLE
Removed unnecessary escapes in regular expressions

### DIFF
--- a/src/Parser/index.js
+++ b/src/Parser/index.js
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
 */
 
-const arrayExpressionRegex = /(\w[^\.\*]+)(\.\*\.?)(.+)?/
+const arrayExpressionRegex = /(\w[^.*]+)(\.\*\.?)(.+)?/
 const _ = require('lodash')
 
 let Parser = exports = module.exports = {}

--- a/src/Raw/index.js
+++ b/src/Raw/index.js
@@ -14,8 +14,8 @@ const moment = require('moment')
 /**
  * list of creepy regex, no they work nice
  */
-const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i
-const emailRegex = /^([\w-]+(?:\.[\w-]+)*)(\+[\w\.-]+)?@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,63}(?:\.[a-z]{2})?)$/i
+const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/i
+const emailRegex = /^([\w-]+(?:\.[\w-]+)*)(\+[\w.-]+)?@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,63}(?:\.[a-z]{2})?)$/i
 const phoneRegex = /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/
 const creditCardRegex = /^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|6(?:011|5[0-9]{2})[0-9]{12}|(?:2131|1800|35\d{3})\d{11})$/
 const alphaNumericRegex = /^[a-z0-9]+$/i


### PR DESCRIPTION
### Hi !
I have removed unnecessary escapes in regular expressions.

**Note that:** Whenever you use Character set in Regular expressions. Special characters like the dot(.) and asterisk (*) are not special inside a character set, so they don't need to be escaped. [Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Using_parenthesized_substring_matches)