### PR TITLE
"Range" should be inclusive

### DIFF
--- a/src/raw/between.js
+++ b/src/raw/between.js
@@ -1,4 +1,8 @@
-export default (input, min, max) => {
+export default (input, min, max, inclusive) => {
   input = Number(input)
-  return (input > Number(min)) && (input < Number(max))
+  if (!inclusive) {
+    return (input > Number(min)) && (input < Number(max))
+  }
+
+  return (input >= Number(min)) && (input <= Number(max))
 }

--- a/src/validations/range.js
+++ b/src/validations/range.js
@@ -28,7 +28,7 @@ export default (data, field, message, [min, max], get) => {
 
     const fieldValue = get(data, field)
 
-    if (!skippable(fieldValue) && !between(fieldValue, min, max)) {
+    if (!skippable(fieldValue) && !between(fieldValue, min, max, true)) {
       return message
     }
   })

--- a/test/node/validations.spec.js
+++ b/test/node/validations.spec.js
@@ -1318,7 +1318,17 @@ test.group('Validations | range', function () {
   test('should work fine when field value is under defined range', async function (assert) {
     const data = {age: 20}
     const field = 'age'
-    const message = 'only adults less than 60 years of age are allowed'
+    const message = 'only adults less or equal than 60 years of age are allowed'
+    const get = prop
+    const args = [18, 60]
+    const passes = await validations.range(data, field, message, args, get)
+    assert.equal(passes, 'validation passed')
+  })
+
+  test('should work fine when field value is equal to minimum defined range', async function (assert) {
+    const data = {age: 18}
+    const field = 'age'
+    const message = 'only adults with or more 18 years of age are allowed'
     const get = prop
     const args = [18, 60]
     const passes = await validations.range(data, field, message, args, get)


### PR DESCRIPTION
If I use the `range` rule with 1,5, if the data is "1" it should work, at this time it fails.
At least I think so, maybe I'm wrong, but in laravel it works like this (inclusive).
